### PR TITLE
add flask api：新增Flask api接口以支持视觉语言聊天模型的交互

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,65 @@ python web_demo_mm.py
 
 <br>
 
+### flask api
+
+We also provide a flask api for users to use our model. Before you start, make sure you install the following packages:
+
+
+
+```
+pip install flask
+```
+
+Then run the command below and you can use the API:
+
+```
+python flaskapi.py
+```
+#### python api request demo
+
+The following is a python demo for the API:
+
+
+
+```
+import json
+import requests
+
+data = {
+    "text": "这是什么",
+    "image_context": {
+        "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"
+    }
+}
+
+
+
+response = requests.post("http://127.0.0.1:5000/chat", json=data)
+response_json = response.json()
+chat_response = response_json.get("response", "")
+print(chat_response)
+
+```
+
+
+#### curl api request demo
+
+```
+curl -X POST \
+ -H "Content-Type: application/json" \
+ -d '{
+       "text": "这是什么", 
+       "image_context": {
+           "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"
+       }
+   }' \
+ http://127.0.0.1:5000/chat
+
+```
+
+<br>
+
 ## FAQ
 
 If you meet problems, please refer to [FAQ](FAQ.md) and the issues first to search a solution before you launch a new issue.

--- a/flaskapi.py
+++ b/flaskapi.py
@@ -1,0 +1,102 @@
+# 导入所需的库和模块
+from flask import Flask, request, jsonify
+from modelscope import (  # 从modelscope库中导入snapshot_download、AutoModelForCausalLM、AutoTokenizer和GenerationConfig
+   snapshot_download,
+   AutoModelForCausalLM,
+   AutoTokenizer,
+   GenerationConfig,
+)
+import torch
+
+# 创建Flask应用实例
+app = Flask(__name__)
+
+# 设置模型ID、修订版本和模型目录
+model_id = 'qwen/Qwen-VL-Chat'
+revision = 'v1.1.0'
+model_dir = snapshot_download(model_id, revision=revision)
+torch.manual_seed(1234)
+
+# 从模型目录中加载分词器和模型
+tokenizer = AutoTokenizer.from_pretrained(model_dir, trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained(model_dir, device_map="auto", trust_remote_code=True, fp16=True).eval()
+model.generation_config = GenerationConfig.from_pretrained(model_dir, trust_remote_code=True)
+
+# 初始化聊天历史记录
+history = None
+
+# 定义'/chat'接口，接受POST请求并返回响应
+@app.route('/chat', methods=['POST'])
+def chat():
+   global history
+   # 从请求中获取图像上下文和文本输入
+   data = request.json
+   image_context = data.get('image_context', {})
+   text_input = data.get('text', '')
+   # 将图像上下文和文本输入转换为分词器格式
+   query = tokenizer.from_list_format([
+       image_context,
+       {'text': text_input},
+   ])
+   # 使用模型进行聊天，并将聊天历史记录传递给下一个接口
+   response, history = model.chat(tokenizer, query=query, history=history)
+   # 返回响应
+   return jsonify({'response': response})
+
+# 定义'/chat_bbox'接口，接受POST请求并返回响应和图像
+@app.route('/chat_bbox', methods=['POST'])
+def chat_bbox():
+   global history
+   # 从请求中获取文本输入
+   text_input = request.json.get('text', '')
+   # 使用模型进行聊天，并将聊天历史记录传递给下一个接口
+   response, history = model.chat(tokenizer, text_input, history=history)
+   # 在响应中添加图像路径
+   image = tokenizer.draw_bbox_on_latest_picture(response, history)
+   image_path = 'output_chat.jpg'
+   image.save(image_path)
+   # 返回响应和图像路径
+   return jsonify({'response': response, 'image_url': image_path})
+
+# 启动Flask应用，监听来自任何IP地址和端口的请求
+if __name__ == '__main__':
+   app.run(host='0.0.0.0', port=5000)
+
+
+
+#readme
+# api请求例子
+"""
+import json
+import requests
+
+data = {
+    "text": "这是什么",
+    "image_context": {
+        "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"
+    }
+}
+
+
+
+response = requests.post("http://127.0.0.1:5000/chat", json=data)
+response_json = response.json()
+chat_response = response_json.get("response", "")
+print(chat_response)
+
+"""
+
+
+# curl请求例子
+"""
+
+curl -X POST \
+ -H "Content-Type: application/json" \
+ -d '{
+       "text": "这是什么", 
+       "image_context": {
+           "image": "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen-VL/assets/demo.jpeg"
+       }
+   }' \
+ http://127.0.0.1:5000/chat
+"""


### PR DESCRIPTION
描述：
本次pull request实现了一个基于Flask框架的简洁API服务器，它提供了两个端点（‘/chat’ 和 ‘/chat_bbox’），允许用户通过POST请求与基于视觉和语言信息的聊天模型进行交互。为了启用这一功能，我们确保了以下几点：

1. 导入了必要的依赖：Flask库用于创建Web服务，modelscope库用于下载并加载预训练的聊天模型，以及torch库以确保结果的一致性。
2. 创建了Flask应用实例，并通过两个POST方法提供了API端点。
3. 通过modelscope库的snapshot_download方法获取到了特定的模型，并利用AutoModelForCausalLM和AutoTokenizer完成了模型及分词器的加载。
4. 设定了模型的生成配置，并初始化了聊天历史记录变量以保持聊天上下文。
5. '/chat' 接口可以接收一个包含文本和视觉上下文的JSON对象，并返回模型根据提供的输入生成的聊天回复。
6. '/chat_bbox' 接口除了返回聊天回复外，还会在最近的图片上绘制边界框，并返回边界框图片的路径。
7. 在底部附加了使用Python的requests库和curl命令行工具发送API请求的示例。

该功能将极大地方便开发者与聊天模型进行交云，并可直接集成到现有应用中以增强其交互能力。此外，通过提供明确的API请求示例，用户能够快速理解如何使用这两个接口与聊天模型交互。
<img width="698" alt="ab87f2cffaf04c7dd576ee553eb71b0" src="https://github.com/QwenLM/Qwen-VL/assets/139489333/00905f3a-3ec4-49b5-be94-996f684c1613">
<img width="639" alt="2d9f712b454e7cc207607728d8805cb" src="https://github.com/QwenLM/Qwen-VL/assets/139489333/de308e09-caf8-4641-951c-fb906465eadc">

<img width="692" alt="80ce2436fec548929222f71f7eeee52" src="https://github.com/QwenLM/Qwen-VL/assets/139489333/96ca13b3-c333-4659-8a32-c2abe68474fe">

