### PR TITLE
[fix]fix evaluation document

### DIFF
--- a/eval_mm/EVALUATION.md
+++ b/eval_mm/EVALUATION.md
@@ -614,7 +614,7 @@ cd ../..
 </details>
 
 <details>
-<summary>Data Preparation</summary>
+<summary>Evaluation</summary>
 
 ```bash
 checkpoint=/PATH/TO/CHECKPOINT


### PR DESCRIPTION
Fix evaluation document, in refcoco+ part, the title of the evaluation section of the code should be "evaluation".